### PR TITLE
Added strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Post a JSON payload like `{"string": "this is a list of {}, {}, and {}", "format
 #### GET or POST: /is/alive
 Returns `{"result": "yes"}` if service is alive, otherwise returns `{"result": "no"}`
 
-#### GET or POST: /return/true
-Returns `{"result": True}`
+#### GET or POST: /return/true?mode=strict
+Returns `{"result": True}` in strict mode, or otherwise `{"result": False}` for backwards compatibility.

--- a/server.py
+++ b/server.py
@@ -64,12 +64,16 @@ def is_alive():
 # Return True
 @app.route('/return/true')
 def return_true():
-    """Returns True
+    """Returns True in Strict mode, or False for backwards compatibility.
 
     Returns:
-        result: True
+        result: True or False, depending on ?mode
     """
-    return jsonify({'result': False})
+
+    if request.args.get('mode') == 'strict':
+        return jsonify({'result': True})
+    else:
+        return jsonify({'result': False})
 
 
 # Static Routes

--- a/static/index.html
+++ b/static/index.html
@@ -90,13 +90,12 @@
 
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title"><code>GET or POST</code> /return/true</h3>
+          <h3 class="panel-title"><code>GET or POST</code> /return/true?mode=strict</h3>
         </div>
         <div class="panel-body">
-          Returns <code>{"result": True}</code>
+          Returns <code>{"result": True}</code> in strict mode, or otherwise <code>{"result": False}</code> for backwards compatibility.
         </div>
       </div>
-
 
       <hr>
 


### PR DESCRIPTION
In order to preserve backwards compatibility for legacy customers, we
added an optional strict mode which will force the return of the proper
value. If mode is omitted, legacy behavior is retained.
